### PR TITLE
Import Custom Objects and Collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Current node options are:
 - KinematicBody2D
 - RigidBody2D
 - StaticBody2D
+- Path to Resource (eg: 'res://Player.tscn'), this will use 'load().instance()' to create your existing node
 
 ## Notes:
 - The example is using the tileset that comes with LDtk: `Cavernas_by_Adam_Saltsman.png`

--- a/README.md
+++ b/README.md
@@ -36,9 +36,10 @@ Can now create tilemaps from autolayers and intgrid layers with tilesets.  Intgr
 
 ## Options:
 - Import_Collisions: If you want to import collision for the tiles (see import collisions below) or not
+- Import_Custom_Entities: If you want to import your own Resources (see entities), this should be set to true. Keep in mind that this will remove the other node options (they will still be imported, but only as Node2D).
 
 ## Importing Collisions:
-- Create a layer called "Collisions", any tile in it will have a RectangleShape2D added to it
+- Create a layer called "Collisions", any tile in it will have a RectangleShape2D added to in a new layer.
 
 ### Entities:
 You can set up how your entities are imported:
@@ -48,11 +49,14 @@ You can set up how your entities are imported:
 4. Set the Default Value to the type of Node
 
 Current node options are:
+1. If not using Custom Entities:
 - Position2D
 - Area2D
 - KinematicBody2D
 - RigidBody2D
 - StaticBody2D
+2. If using Custom Entities:
+- Position2D, Area2D, KinematicBody2D, RigidBody2D, and StaticBody2D will be imported as Node2D
 - Path to Resource (eg: 'res://Player.tscn'), this will use 'load().instance()' to create your existing node
 
 ## Notes:

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Can now create tilemaps from autolayers and intgrid layers with tilesets.  Intgr
 ## Options:
 - Import_Collisions: If you want to import collision for the tiles (see import collisions below) or not
 - Import_Custom_Entities: If you want to import your own Resources (see entities), this should be set to true. Keep in mind that this will remove the other node options (they will still be imported, but only as Node2D).
+- Import_Metadata: If set, will import any fields set on the entities as metadata (using 'set_meta()'). They can be retrieved later using 'get_meta()' on the imported object.
 
 ## Importing Collisions:
 - Create a layer called "Collisions", any tile in it will have a RectangleShape2D added to in a new layer.
@@ -47,6 +48,7 @@ You can set up how your entities are imported:
 2. Add a String Field Type
 3. Set the Field Identifier to: `NodeType`
 4. Set the Default Value to the type of Node
+5. Any fields added to the entity can be added as metadata if the option is set when importing (retrieve using the function 'get_meta()' on the object after importing)
 
 Current node options are:
 1. If not using Custom Entities:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Can now create tilemaps from autolayers and intgrid layers with tilesets.  Intgr
 ## Options:
 - Import_Collisions: If you want to import collision for the tiles (see import collisions below) or not
 - Import_Custom_Entities: If you want to import your own Resources (see entities), this should be set to true. Keep in mind that this will remove the other node options (they will still be imported, but only as Node2D).
-- Import_Metadata: If set, will import any fields set on the entities as metadata (using 'set_meta()'). They can be retrieved later using 'get_meta()' on the imported object.
+- Import_Metadata: If set, will import any fields set on the entities. If they have an exported property with the same name, it will set the value of the property with the value on LDtk, if they don't (or the plugin can't find it), they will be imported as metadata (using 'set_meta()') and can be retrieved later using 'get_meta()' on the imported object.
 
 ## Importing Collisions:
 - Create a layer called "Collisions", any tile in it will have a RectangleShape2D added to in a new layer.
@@ -48,7 +48,7 @@ You can set up how your entities are imported:
 2. Add a String Field Type
 3. Set the Field Identifier to: `NodeType`
 4. Set the Default Value to the type of Node
-5. Any fields added to the entity can be added as metadata if the option is set when importing (retrieve using the function 'get_meta()' on the object after importing)
+5. Any fields added to the entity on LDtk can set properties on the object or be added as metadata if the option is set when importing (retrieve using the function 'get_meta()' on the object after importing)
 
 Current node options are:
 1. If not using Custom Entities:

--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ Can now create tilemaps from autolayers and intgrid layers with tilesets.  Intgr
 - IntGrid, Tiles, and AutoLayers are imported as TileMap Nodes.
 - Currently Entities have very basic functionality, checkout the testmap.ldtk for examples.
 
+## Options:
+- Import_Collisions: If you want to import collision for the tiles (see import collisions below) or not
+
+## Importing Collisions:
+- Create a layer called "Collisions", any tile in it will have a RectangleShape2D added to it
+
 ### Entities:
 You can set up how your entities are imported:
 1. Create a new Entity

--- a/addons/LDtk-Importer/LDtk.gd
+++ b/addons/LDtk-Importer/LDtk.gd
@@ -59,6 +59,8 @@ func new_entity(entity_data, level):
 							printerr("Could not load resource: ", field.__value)
 							return
 						new_entity = resource.instance()
+						new_entity.position = Vector2(entity_data.px[0] + level.worldX, entity_data.px[1] + level.worldY)
+						return new_entity
 	else:
 		return
 
@@ -93,13 +95,13 @@ func get_entity_size(entity_identifier):
 
 
 #create new TileMap from tilemap_data.
-func new_tilemap(tilemap_data, level):
+func new_tilemap(tilemap_data, level, options):
 	if tilemap_data.__type == 'IntGrid' and get_layer_tileset_data(tilemap_data.layerDefUid) == null:
 		return
 
 	var tilemap = TileMap.new()
 	var tileset_data = get_layer_tileset_data(tilemap_data.layerDefUid)
-	tilemap.tile_set = new_tileset(tileset_data)
+	tilemap.tile_set = new_tileset(tileset_data, options.Import_Collisions)
 	tilemap.name = tilemap_data.__identifier
 	tilemap.position = Vector2(level.worldX, level.worldY)
 	tilemap.cell_size = Vector2(tilemap_data.__gridSize, tilemap_data.__gridSize)
@@ -123,12 +125,11 @@ func new_tilemap(tilemap_data, level):
 				tilemap.set_cellv(grid_coords, tile.d[1], flipX, flipY)
 				tilemap.set_cellv(grid_coords, tile.t, flipX, flipY)
 
-
 	return tilemap
 
 
 #create new tileset from tileset_data.
-func new_tileset(tileset_data):
+func new_tileset(tileset_data, import_collisions):
 	var tileset = TileSet.new()
 	var texture_filepath = map_data.base_dir + '/' + tileset_data.relPath
 	var texture = load(texture_filepath)
@@ -139,6 +140,11 @@ func new_tileset(tileset_data):
 	var gridHeight = (tileset_data.pxHei - tileset_data.padding) / (tileset_data.tileGridSize + tileset_data.spacing)
 	var gridSize = gridWidth * gridHeight
 
+	var collision
+	if import_collisions:
+		collision = RectangleShape2D.new()
+		collision.extents = Vector2(tileset_data.tileGridSize, tileset_data.pxWid / tileset_data.tileGridSize)
+	
 	for tileId in range(0, gridSize):
 		var tile_image = texture_image.get_rect(get_tile_region(tileId, tileset_data))
 		if not tile_image.is_invisible():
@@ -146,6 +152,8 @@ func new_tileset(tileset_data):
 			tileset.tile_set_tile_mode(tileId, TileSet.SINGLE_TILE)
 			tileset.tile_set_texture(tileId, texture)
 			tileset.tile_set_region(tileId, get_tile_region(tileId, tileset_data))
+			if import_collisions:
+				tileset.tile_set_shape(tileId, tileId, collision)
 
 	return tileset
 

--- a/addons/LDtk-Importer/LDtk.gd
+++ b/addons/LDtk-Importer/LDtk.gd
@@ -84,7 +84,7 @@ func get_entity_size(entity_identifier):
 
 
 #create new TileMap from tilemap_data.
-func new_tilemap(tilemap_data):
+func new_tilemap(tilemap_data, level):
 	if tilemap_data.__type == 'IntGrid' and get_layer_tileset_data(tilemap_data.layerDefUid) == null:
 		return
 
@@ -92,7 +92,7 @@ func new_tilemap(tilemap_data):
 	var tileset_data = get_layer_tileset_data(tilemap_data.layerDefUid)
 	tilemap.tile_set = new_tileset(tileset_data)
 	tilemap.name = tilemap_data.__identifier
-	tilemap.position = Vector2(tilemap_data.__pxTotalOffsetX, tilemap_data.__pxTotalOffsetY)
+	tilemap.position = Vector2(level.worldX, level.worldY)
 	tilemap.cell_size = Vector2(tilemap_data.__gridSize, tilemap_data.__gridSize)
 	tilemap.modulate = Color(1,1,1, tilemap_data.__opacity)
 

--- a/addons/LDtk-Importer/LDtk.gd
+++ b/addons/LDtk-Importer/LDtk.gd
@@ -53,7 +53,12 @@ func new_entity(entity_data):
 						new_entity = RigidBody2D.new()
 					'StaticBody2D':
 						new_entity = StaticBody2D.new()
+					_:
+						return
 	else:
+		return
+
+	if not new_entity:
 		return
 
 	match new_entity.get_class():

--- a/addons/LDtk-Importer/LDtk.gd
+++ b/addons/LDtk-Importer/LDtk.gd
@@ -24,13 +24,13 @@ func load_LDtk_file(filepath):
 
 
 #get layer entities
-func get_layer_entities(layer, level):
+func get_layer_entities(layer, level, options):
 	if layer.__type != 'Entities':
 		return
 
 	var entities = []
 	for entity in layer.entityInstances:
-		var new_entity = new_entity(entity, level)
+		var new_entity = new_entity(entity, level, options)
 		if new_entity:
 			entities.append(new_entity)
 
@@ -38,7 +38,7 @@ func get_layer_entities(layer, level):
 
 
 #create new entity
-func new_entity(entity_data, level):
+func new_entity(entity_data, level, options):
 	var new_entity
 	if entity_data.fieldInstances:
 		for field in entity_data.fieldInstances:
@@ -55,6 +55,9 @@ func new_entity(entity_data, level):
 					'StaticBody2D':
 						new_entity = StaticBody2D.new()
 					_:
+						if not options.Import_Custom_Entities:
+							return
+
 						var resource = load(field.__value)
 						if not resource:
 							printerr("Could not load resource: ", field.__value)

--- a/addons/LDtk-Importer/LDtk.gd
+++ b/addons/LDtk-Importer/LDtk.gd
@@ -54,7 +54,11 @@ func new_entity(entity_data, level):
 					'StaticBody2D':
 						new_entity = StaticBody2D.new()
 					_:
-						return
+						var resource = load(field.__value)
+						if not resource:
+							printerr("Could not load resource: ", field.__value)
+							return
+						new_entity = resource.instance()
 	else:
 		return
 

--- a/addons/LDtk-Importer/LDtk.gd
+++ b/addons/LDtk-Importer/LDtk.gd
@@ -24,20 +24,20 @@ func load_LDtk_file(filepath):
 
 
 #get layer entities
-func get_layer_entities(layer):
+func get_layer_entities(layer, level):
 	if layer.__type != 'Entities':
 		return
 
 	var entities = []
 	for entity in layer.entityInstances:
-		var new_entity = new_entity(entity)
+		var new_entity = new_entity(entity, level)
 		entities.append(new_entity)
 
 	return entities
 
 
 #create new entity
-func new_entity(entity_data):
+func new_entity(entity_data, level):
 	var new_entity
 	if entity_data.fieldInstances:
 		for field in entity_data.fieldInstances:
@@ -67,7 +67,7 @@ func new_entity(entity_data):
 			new_entity.add_child(col_shape)
 
 	new_entity.name = entity_data.__identifier
-	new_entity.position = Vector2(entity_data.px[0], entity_data.px[1])
+	new_entity.position = Vector2(entity_data.px[0] + level.worldX, entity_data.px[1] + level.worldY)
 
 	return new_entity
 

--- a/addons/LDtk-Importer/LDtk.gd
+++ b/addons/LDtk-Importer/LDtk.gd
@@ -78,7 +78,10 @@ func new_entity(entity_data, level, options):
 		return
 
 	for data in metadata:
-		new_entity.set_meta(data['name'], data['value'])
+		if data['name'] in new_entity:
+			new_entity[data['name']] = data['value']
+		else:
+			new_entity.set_meta(data['name'], data['value'])
 
 	if is_custom_entity:
 		return new_entity

--- a/addons/LDtk-Importer/LDtk.gd
+++ b/addons/LDtk-Importer/LDtk.gd
@@ -31,7 +31,8 @@ func get_layer_entities(layer, level):
 	var entities = []
 	for entity in layer.entityInstances:
 		var new_entity = new_entity(entity, level)
-		entities.append(new_entity)
+		if new_entity:
+			entities.append(new_entity)
 
 	return entities
 
@@ -62,6 +63,7 @@ func new_entity(entity_data, level):
 						new_entity.position = Vector2(entity_data.px[0] + level.worldX, entity_data.px[1] + level.worldY)
 						return new_entity
 	else:
+		printerr("Could not load entity data: ", entity_data)
 		return
 
 	if not new_entity:

--- a/addons/LDtk-Importer/LDtk.gd
+++ b/addons/LDtk-Importer/LDtk.gd
@@ -40,6 +40,9 @@ func get_layer_entities(layer, level, options):
 #create new entity
 func new_entity(entity_data, level, options):
 	var new_entity
+	var metadata = []
+	
+	var is_custom_entity = false
 	if entity_data.fieldInstances:
 		for field in entity_data.fieldInstances:
 			if field.__identifier == 'NodeType' and field.__type == 'String':
@@ -64,13 +67,21 @@ func new_entity(entity_data, level, options):
 							return
 						new_entity = resource.instance()
 						new_entity.position = Vector2(entity_data.px[0] + level.worldX, entity_data.px[1] + level.worldY)
-						return new_entity
+						is_custom_entity = true
+			elif options.Import_Metadata:
+				metadata.append({'name': field.__identifier, 'value': field.__value})
 	else:
 		printerr("Could not load entity data: ", entity_data)
 		return
 
 	if not new_entity:
 		return
+
+	for data in metadata:
+		new_entity.set_meta(data['name'], data['value'])
+
+	if is_custom_entity:
+		return new_entity
 
 	match new_entity.get_class():
 		'Area2D', 'KinematicBody2D', 'RigidBody2D', 'StaticBody2D':

--- a/addons/LDtk-Importer/LDtkImporter.gd
+++ b/addons/LDtk-Importer/LDtkImporter.gd
@@ -92,7 +92,7 @@ func get_level_layerInstances(level):
 
 				layers.append(new_node)
 			'Tiles', 'IntGrid', 'AutoLayer':
-				var new_layer = LDtk.new_tilemap(layerInstance)
+				var new_layer = LDtk.new_tilemap(layerInstance, level)
 				if new_layer:
 					layers.append(new_layer)
 

--- a/addons/LDtk-Importer/LDtkImporter.gd
+++ b/addons/LDtk-Importer/LDtkImporter.gd
@@ -101,8 +101,13 @@ func get_level_layerInstances(level, options):
 
 				layers.append(new_node)
 			'Tiles', 'IntGrid', 'AutoLayer':
-				var new_layer = LDtk.new_tilemap(layerInstance, level, options)
+				var new_layer = LDtk.new_tilemap(layerInstance, level)
 				if new_layer:
 					layers.append(new_layer)
+
+		if layerInstance.__type == 'IntGrid':
+			var collision_layer = LDtk.import_collisions(layerInstance, level, options)
+			if collision_layer:
+				layers.append(collision_layer)
 
 	return layers

--- a/addons/LDtk-Importer/LDtkImporter.gd
+++ b/addons/LDtk-Importer/LDtkImporter.gd
@@ -50,6 +50,11 @@ func get_import_options(preset):
 		{
 			"name": "Import_Collisions",
 			"default_value": preset == Presets.PRESET_COLLISIONS
+		},
+		{
+			"name": "Import_Custom_Entities",
+			"default_value": true,
+			"hint_string": "If true, will only use this project's scenes. If false, will import objects as simple scenes."
 		}
 	]
 
@@ -78,6 +83,10 @@ func import(source_file, save_path, options, platform_v, r_gen_files):
 
 			for child in layerInstance.get_children():
 				child.set_owner(map)
+				
+				if not options.Import_Custom_Entities:
+					for grandchild in child.get_children():
+						grandchild.set_owner(map)
 
 	var packed_scene = PackedScene.new()
 	packed_scene.pack(map)
@@ -93,7 +102,7 @@ func get_level_layerInstances(level, options):
 			'Entities':
 				var new_node = Node2D.new()
 				new_node.name = layerInstance.__identifier
-				var entities = LDtk.get_layer_entities(layerInstance, level)
+				var entities = LDtk.get_layer_entities(layerInstance, level, options)
 				for entity in entities:
 					new_node.add_child(entity)
 

--- a/addons/LDtk-Importer/LDtkImporter.gd
+++ b/addons/LDtk-Importer/LDtkImporter.gd
@@ -2,7 +2,7 @@ tool
 extends EditorImportPlugin
 
 
-enum { PRESET_DEFAULT }
+enum Presets { PRESET_DEFAULT, PRESET_COLLISIONS }
 var LDtk = preload("LDtk.gd").new()
 
 
@@ -35,17 +35,26 @@ func get_save_extension():
 
 
 func get_preset_count():
-	return 1
+	return Presets.size()
 
 
 func get_preset_name(preset):
 	match preset:
-		PRESET_DEFAULT: return "Default"
-
+		Presets.PRESET_DEFAULT:
+			return "Default"
+		Presets.PRESET_COLLISIONS:
+			return "Import Collisions"
 
 func get_import_options(preset):
-	return
+	return [
+		{
+			"name": "Import_Collisions",
+			"default_value": preset == Presets.PRESET_COLLISIONS
+		}
+	]
 
+func get_option_visibility(option, options):
+	return true
 
 func import(source_file, save_path, options, platform_v, r_gen_files):
 	#load LDtk map
@@ -62,7 +71,7 @@ func import(source_file, save_path, options, platform_v, r_gen_files):
 		new_level.set_owner(map)
 
 		#add layers
-		var layerInstances = get_level_layerInstances(level)
+		var layerInstances = get_level_layerInstances(level, options)
 		for layerInstance in layerInstances:
 			new_level.add_child(layerInstance)
 			layerInstance.set_owner(map)
@@ -79,7 +88,7 @@ func import(source_file, save_path, options, platform_v, r_gen_files):
 
 
 #create layers in level
-func get_level_layerInstances(level):
+func get_level_layerInstances(level, options):
 	var layers = []
 	for layerInstance in level.layerInstances:
 		match layerInstance.__type:
@@ -92,7 +101,7 @@ func get_level_layerInstances(level):
 
 				layers.append(new_node)
 			'Tiles', 'IntGrid', 'AutoLayer':
-				var new_layer = LDtk.new_tilemap(layerInstance, level)
+				var new_layer = LDtk.new_tilemap(layerInstance, level, options)
 				if new_layer:
 					layers.append(new_layer)
 

--- a/addons/LDtk-Importer/LDtkImporter.gd
+++ b/addons/LDtk-Importer/LDtkImporter.gd
@@ -86,7 +86,7 @@ func get_level_layerInstances(level):
 			'Entities':
 				var new_node = Node2D.new()
 				new_node.name = layerInstance.__identifier
-				var entities = LDtk.get_layer_entities(layerInstance)
+				var entities = LDtk.get_layer_entities(layerInstance, level)
 				for entity in entities:
 					new_node.add_child(entity)
 

--- a/addons/LDtk-Importer/LDtkImporter.gd
+++ b/addons/LDtk-Importer/LDtkImporter.gd
@@ -55,6 +55,11 @@ func get_import_options(preset):
 			"name": "Import_Custom_Entities",
 			"default_value": true,
 			"hint_string": "If true, will only use this project's scenes. If false, will import objects as simple scenes."
+		},
+		{
+			"name": "Import_Metadata",
+			"default_value": true,
+			"hint_string": "If true, will import entity fields as metadata."
 		}
 	]
 

--- a/addons/LDtk-Importer/LDtkImporter.gd
+++ b/addons/LDtk-Importer/LDtkImporter.gd
@@ -97,10 +97,12 @@ func import(source_file, save_path, options, platform_v, r_gen_files):
 #create layers in level
 func get_level_layerInstances(level, options):
 	var layers = []
+	var i = level.layerInstances.size()
 	for layerInstance in level.layerInstances:
 		match layerInstance.__type:
 			'Entities':
 				var new_node = Node2D.new()
+				new_node.z_index = i
 				new_node.name = layerInstance.__identifier
 				var entities = LDtk.get_layer_entities(layerInstance, level, options)
 				for entity in entities:
@@ -110,11 +112,15 @@ func get_level_layerInstances(level, options):
 			'Tiles', 'IntGrid', 'AutoLayer':
 				var new_layer = LDtk.new_tilemap(layerInstance, level)
 				if new_layer:
+					new_layer.z_index = i
 					layers.push_front(new_layer)
 
 		if layerInstance.__type == 'IntGrid':
 			var collision_layer = LDtk.import_collisions(layerInstance, level, options)
 			if collision_layer:
+				collision_layer.z_index = i
 				layers.push_front(collision_layer)
+
+		i -= 1
 
 	return layers

--- a/addons/LDtk-Importer/LDtkImporter.gd
+++ b/addons/LDtk-Importer/LDtkImporter.gd
@@ -99,15 +99,15 @@ func get_level_layerInstances(level, options):
 				for entity in entities:
 					new_node.add_child(entity)
 
-				layers.append(new_node)
+				layers.push_front(new_node)
 			'Tiles', 'IntGrid', 'AutoLayer':
 				var new_layer = LDtk.new_tilemap(layerInstance, level)
 				if new_layer:
-					layers.append(new_layer)
+					layers.push_front(new_layer)
 
 		if layerInstance.__type == 'IntGrid':
 			var collision_layer = LDtk.import_collisions(layerInstance, level, options)
 			if collision_layer:
-				layers.append(collision_layer)
+				layers.push_front(collision_layer)
 
 	return layers

--- a/addons/LDtk-Importer/LDtkImporter.gd
+++ b/addons/LDtk-Importer/LDtkImporter.gd
@@ -78,8 +78,6 @@ func import(source_file, save_path, options, platform_v, r_gen_files):
 
 			for child in layerInstance.get_children():
 				child.set_owner(map)
-				for grandchild in child.get_children():
-					grandchild.set_owner(map)
 
 	var packed_scene = PackedScene.new()
 	packed_scene.pack(map)


### PR DESCRIPTION
With this PR, we should be able to use our own objects (eg: Player, Items, etc), import collisions from LDtk, and import entity fields as metadata. Also fixed a few issues I found while using this plugin.

- Makes it possible to import correctly the large map sample with their correct coordinates (both for the levels and for the entities).
- Fixed one error for using a null entity when it was not properly configured on LDtk.
- Added the possibility to load existing resources using the path to it instead of the supported NodeTypes.
- Added the option to import collisions (added to the README) by having a "Collisions" layer, and it creates a StaticBody2D with one object per tile that needs collision (whatever was added in that layer). It's way faster than adding collision on each tileset for some reason. Also it would be nice to optimize this later by simplifying the geometry (aka use less collision nodes), we can do that if we also consider the Y axis, but the logic is a bit more complicated for that.
- Use the correct rendering order from LDtk.
- Add entity fields to the node property (it it exists) or as metadata.
- It will start requiring LDtk 0.8.0