### PR TITLE
Added ability to add light occluder

### DIFF
--- a/addons/LDtk-Importer/LDtk.gd
+++ b/addons/LDtk-Importer/LDtk.gd
@@ -166,6 +166,13 @@ func new_tileset(tilemap_data, tileset_data):
 			tileset.tile_set_tile_mode(tileId, TileSet.SINGLE_TILE)
 			tileset.tile_set_texture(tileId, texture)
 			tileset.tile_set_region(tileId, get_tile_region(tileId, tileset_data))
+			
+			for data in tileset_data.customData:
+				if tileId == data.tileId:
+					var jsonObj = parse_json(data.data)
+					
+					if jsonObj.light_occluder:
+						tileset.tile_set_light_occluder(tileId, get_tile_light_occluder(tileId, tileset_data))
 
 	return tileset
 
@@ -297,3 +304,17 @@ func get_collision_shape(tile_size, start_position, end_position, tile_count):
 	col_shape.position.y = ((start_position.y + end_position.y) / 2)
 	
 	return col_shape
+
+# Returns a OccluderPolygon2D for the given tile
+func get_tile_light_occluder(tileId, tileset_data):
+	var region = get_tile_region(tileId, tileset_data)
+	var polygon = OccluderPolygon2D.new()
+	
+	polygon.set_polygon(PoolVector2Array([
+		Vector2(region.size.x, 0), # top right
+		region.size,               # bottom right
+		Vector2(0, region.size.y), # bottom left
+		Vector2.ZERO               # top left
+	]))
+	
+	return polygon

--- a/addons/LDtk-Importer/LDtk.gd
+++ b/addons/LDtk-Importer/LDtk.gd
@@ -171,7 +171,9 @@ func new_tileset(tilemap_data, tileset_data):
 				if tileId == data.tileId:
 					var jsonObj = parse_json(data.data)
 					
-					if jsonObj.light_occluder:
+					if "light_occluder_shape" in data.data:
+						tileset.tile_set_light_occluder(tileId, get_tile_light_occluder_custom_shape(tileId, jsonObj.light_occluder_shape))
+					elif "light_occluder" in jsonObj and jsonObj.light_occluder == true: 
 						tileset.tile_set_light_occluder(tileId, get_tile_light_occluder(tileId, tileset_data))
 
 	return tileset
@@ -316,5 +318,17 @@ func get_tile_light_occluder(tileId, tileset_data):
 		Vector2(0, region.size.y), # bottom left
 		Vector2.ZERO               # top left
 	]))
+	
+	return polygon
+
+# Returns a OccluderPolygon2D for the given tile with a predefined custom shape.
+func get_tile_light_occluder_custom_shape(tileId, pointArray):
+	var polygon = OccluderPolygon2D.new()
+	
+	var list = PoolVector2Array()
+	for a in pointArray:
+		list.append(Vector2(a.x, a.y))
+	
+	polygon.set_polygon(list)
 	
 	return polygon


### PR DESCRIPTION
Ability to automatically create light occluder in Godot by specifying some data as custom data on the tiles in LDtk.

If `{
  "light_occluder": true
}` is attached it will create a simple square occluder filling the whole tile.

But you can also specify a custom shape to for example have rounded corners like this. 
```
{
  "light_occluder_shape": [
    {"x": 64, "y": 15},
    {"x": 64, "y": 64},
    {"x": 0, "y": 64},
    {"x": 0, "y": 0},
    {"x": 48, "y": 0},
    {"x": 55, "y": 3.2},
    {"x": 60, "y": 8.8}
  ]
}

```
<img width="933" alt="image" src="https://user-images.githubusercontent.com/22000931/128155747-77a6f8b7-0072-4f28-bbb3-9286fe2c6b16.png">
