### PR TITLE
load level's fields as metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Can now create tilemaps from autolayers and intgrid layers with tilesets.  Intgr
 ## Import Menu Options:
 - Import_Collisions: Import collisions from IntGrid layer (see import collisions below).
 - Import_Custom_Entities: Import your own Resources (see entities). Keep in mind that this will remove the other node options (they will still be imported, but only as Node2D).
-- Import_Metadata: Import any fields set on entities. If they have an exported property with the same name, it will set the value of the property with the value on LDtk, if they don't (or the plugin can't find it), they will be imported as metadata (using 'set_meta()') and can be retrieved later using 'get_meta()' on the imported object.
+- Import_Metadata: Import any fields set on entities or levels. For entities, If they have an exported property with the same name, it will set the value of the property with the value on LDtk, if they don't (or the plugin can't find it), they will be imported as metadata (using 'set_meta()') and can be retrieved later using 'get_meta()' on the imported object. Level's fields will all be imported as metadata.
 - Import_YSort_Entities_Layer: Any Entities Layer whose name begins with "YSort" will be imported as a YSort node, and all the entities will be set as children of this YSort node.
 - Post_Import_Script: The selected script will have it's `post_import(scene)` method run. This
 enables you to change the generated scene automatically upon each reimport.

--- a/addons/LDtk-Importer/LDtkImporter.gd
+++ b/addons/LDtk-Importer/LDtkImporter.gd
@@ -60,7 +60,7 @@ func get_import_options(preset):
 		{
 			"name": "Import_Metadata",
 			"default_value": true,
-			"hint_string": "If true, will import entity fields as metadata."
+			"hint_string": "If true, will import entity and level fields as metadata."
 		},
 		{
 			"name": "Import_YSort_Entities_Layer",
@@ -91,6 +91,17 @@ func import(source_file, save_path, options, platform_v, r_gen_files):
 		var new_level = Node2D.new()
 		new_level.name = level.identifier
 		new_level.position = Vector2(level.worldX, level.worldY)
+
+#import level metadata
+		if options.Import_Metadata:
+			for property in level:
+				if not property in ["layerInstances"]:
+					if property == "fieldInstances":
+						for field in level.fieldInstances:
+							new_level.set_meta(field.__identifier, field.__value)
+					else:
+						new_level.set_meta(property, level[property])
+
 		map.add_child(new_level)
 		new_level.set_owner(map)
 


### PR DESCRIPTION
Currently, even if Import_Metadata is enabled, the fields of the level are not imported. I tend to think this is a bug. This PR allows the level's fields to be imported as metadata as well.

The reason for skipping "layerInstances" field is that this field contains too much data (thousands), much of it about rules. I don't think importing this field will be very useful.

Screenshot: (powered by [Metadata Inspector](https://github.com/ballerburg9005/godot-metadata-inspector))

![image](https://user-images.githubusercontent.com/40604180/179416281-4ec78a7f-5fd5-4f57-a617-e8de29ee411f.png)
![image](https://user-images.githubusercontent.com/40604180/179416293-3ae6ae8b-cf63-4e6f-9c83-50191acda33e.png)

